### PR TITLE
Destroy Game Properly On Leaving

### DIFF
--- a/app/src/main/java/com/bestCatHustlers/sukodublitz/game/GameActivity.java
+++ b/app/src/main/java/com/bestCatHustlers/sukodublitz/game/GameActivity.java
@@ -72,6 +72,13 @@ public class GameActivity extends AppCompatActivity implements GameContract.View
     }
 
     @Override
+    protected void onDestroy() {
+        super.onDestroy();
+
+        presenter.handleViewDestroyed();
+    }
+
+    @Override
     public void onWindowFocusChanged(boolean hasFocus) {
         super.onWindowFocusChanged(hasFocus);
         if (hasFocus) {
@@ -184,6 +191,8 @@ public class GameActivity extends AppCompatActivity implements GameContract.View
                         Intent intent = new Intent(baseContext, MainActivity.class);
 
                         baseContext.startActivity(intent);
+
+                        finish();
                     }
                 });
 
@@ -208,6 +217,8 @@ public class GameActivity extends AppCompatActivity implements GameContract.View
                                 dialog.dismiss();
 
                                 openResultsActivity(null);
+
+                                finish();
                             }
                         });
 

--- a/app/src/main/java/com/bestCatHustlers/sukodublitz/game/GameContract.java
+++ b/app/src/main/java/com/bestCatHustlers/sukodublitz/game/GameContract.java
@@ -20,6 +20,8 @@ public class GameContract {
     interface Presenter {
         void handleViewCreated();
 
+        void handleViewDestroyed();
+
         void handleCellClick(int row, int column);
 
         void handleNumberClick(int number);

--- a/app/src/main/java/com/bestCatHustlers/sukodublitz/game/GamePresenter.java
+++ b/app/src/main/java/com/bestCatHustlers/sukodublitz/game/GamePresenter.java
@@ -67,6 +67,11 @@ public class GamePresenter implements GameContract.Presenter, GameAI.Delegate {
     }
 
     @Override
+    public void handleViewDestroyed() {
+        aiThread.interrupt();
+    }
+
+    @Override
     public void handleCellClick(int row, int column) {
         if (model.getBoard()[row][column] > 0) return;
 


### PR DESCRIPTION
The changes made will destroy the game activity upon leaving the game, or finishing the game. This includes interrupting the thread that the ai is running on when the game view is destroyed, so that it will not run in the background.