### PR TITLE
Allow Selecting Teams In Lobby

### DIFF
--- a/app/src/main/java/com/bestCatHustlers/sukodublitz/GameAI.java
+++ b/app/src/main/java/com/bestCatHustlers/sukodublitz/GameAI.java
@@ -1,7 +1,5 @@
 package com.bestCatHustlers.sukodublitz;
 
-import com.bestCatHustlers.sukodublitz.game.GamePresenter;
-
 import java.util.Random;
 
 /*
@@ -46,7 +44,7 @@ public class GameAI implements Runnable
         {
             try
             {
-                Thread.sleep(delayMs);
+                Thread.sleep(delayMs + (rand.nextInt(delayMs) * 2));
                 board = game.getBoard();
                 solver.setPuzzle(board);
                 ThreeTuple single = solver.findNakedSingle();

--- a/app/src/main/java/com/bestCatHustlers/sukodublitz/PuzzleGenerator.java
+++ b/app/src/main/java/com/bestCatHustlers/sukodublitz/PuzzleGenerator.java
@@ -43,6 +43,7 @@ public class PuzzleGenerator implements Parcelable, Serializable
         rotate(seeds, 1);
         shuffle(seeds);
         rotate(seeds, rand.nextInt(4));
+        shift(seeds, rand.nextInt(9));
         // TODO: Permute band, stack, and cells
 
         int[][] solution = new int[GRID_SIZE][];
@@ -52,6 +53,16 @@ public class PuzzleGenerator implements Parcelable, Serializable
         }
         backtrack(solution);
         return new Puzzle(seeds, solution);
+    }
+
+    private void shift(int [][] board, int delta) {
+        for (int row = 0; row < GRID_SIZE; ++row) {
+            for (int column = 0; column < GRID_SIZE; ++column) {
+                if (board[row][column] == 0) { continue; }
+
+                board[row][column] = ((board[row][column] + delta) % GRID_SIZE) + 1;
+            }
+        }
     }
 
     // Rotate matrix 90 degrees clockwise n times

--- a/app/src/main/java/com/bestCatHustlers/sukodublitz/game/GameActivity.java
+++ b/app/src/main/java/com/bestCatHustlers/sukodublitz/game/GameActivity.java
@@ -361,5 +361,12 @@ public class GameActivity extends AppCompatActivity implements GameContract.View
         mBluetoothService.write(message);
     }
 
+    @Override
+    public void setTeamColor(int color) {
+        for (TextView button : numberEntryButtons) {
+            button.setTextColor(getResources().getColor(color));
+        }
+    }
+
     //endregion
 }

--- a/app/src/main/java/com/bestCatHustlers/sukodublitz/game/GameContract.java
+++ b/app/src/main/java/com/bestCatHustlers/sukodublitz/game/GameContract.java
@@ -30,6 +30,8 @@ public class GameContract {
         void showTimer(boolean shouldShowTimer);
 
         void sendBluetoothMessage(byte[] message);
+
+        void setTeamColor(int color);
     }
 
     interface Presenter {

--- a/app/src/main/java/com/bestCatHustlers/sukodublitz/game/GamePresenter.java
+++ b/app/src/main/java/com/bestCatHustlers/sukodublitz/game/GamePresenter.java
@@ -283,6 +283,13 @@ public class GamePresenter implements GameContract.Presenter, GameAI.Delegate {
         }
 
         model.setWrongAnsDelta(isPenaltyOn ? Constants.penaltyDelta : 0);
+
+        Player self = model.getPlayer(MainSettingsModel.getInstance().getUserID());
+
+        if (self != null) {
+            int teamColor = self.getTeam() == Player.Team.RED ? R.color.secondaryDarkColor : R.color.primaryDarkColor;
+            view.setTeamColor(teamColor);
+        }
     }
 
     private void handleBluetoothMessageRead(Message rawMessage) {

--- a/app/src/main/java/com/bestCatHustlers/sukodublitz/lobby/LobbyActivity.java
+++ b/app/src/main/java/com/bestCatHustlers/sukodublitz/lobby/LobbyActivity.java
@@ -9,6 +9,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.Message;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 
 import android.view.View;
@@ -29,6 +30,7 @@ public class LobbyActivity extends AppCompatActivity implements LobbyContract.Vi
     private BluetoothService mBluetoothService = null;
 
     private TextView textStatus;
+    private Button buttonToggleTeam;
     private Button buttonStartGame;
 
     boolean mBounded;
@@ -59,6 +61,7 @@ public class LobbyActivity extends AppCompatActivity implements LobbyContract.Vi
         checkBluetoothSupport();
 
         textStatus = findViewById(R.id.text_show_lobby_status);
+        buttonToggleTeam = findViewById(R.id.button_lobby_toggle_team);
         buttonStartGame = findViewById(R.id.button_lobby_start_game);
 
         presenter.handleViewCreated();
@@ -108,6 +111,10 @@ public class LobbyActivity extends AppCompatActivity implements LobbyContract.Vi
 
     public void onStartGamePressed(View view) {
         presenter.handleStartGamePressed();
+    }
+
+    public void onToggleTeamPressed(View view) {
+        presenter.handleToggleTeamPressed();
     }
 
     public void checkBluetoothSupport() {
@@ -176,22 +183,10 @@ public class LobbyActivity extends AppCompatActivity implements LobbyContract.Vi
         }
     }
 
-    //endregion
-
-    //region Private
-
-    private void sendMessage(String message) {
-        // Check that we're actually connected before trying anything
-        if (mBluetoothService.getState() != BluetoothConstants.STATE_CONNECTED) {
-            Toast.makeText(this, "Not connected to a device", Toast.LENGTH_SHORT).show();
-            return;
-        }
-        // Check that there's actually something to send
-        if (message.length() > 0) {
-            // Get the message bytes and tell the BluetoothChatService to write
-            byte[] send = SerializableUtils.serialize(message);
-            mBluetoothService.write(send);
-        }
+    @Override
+    public void setToggleTeamButton(int color, String text) {
+        buttonToggleTeam.setBackgroundTintList(ContextCompat.getColorStateList(this, color));
+        buttonToggleTeam.setText(text);
     }
 
     //endregion

--- a/app/src/main/java/com/bestCatHustlers/sukodublitz/lobby/LobbyContract.java
+++ b/app/src/main/java/com/bestCatHustlers/sukodublitz/lobby/LobbyContract.java
@@ -16,6 +16,8 @@ public class LobbyContract {
         void openDiscoverableAlert(int durationSeconds);
 
         void setStartGameVisibility(int visibility);
+
+        void setToggleTeamButton(int color, String text);
     }
 
     interface Presenter {
@@ -30,6 +32,8 @@ public class LobbyContract {
         void handleBluetoothMessageReceived(Message message);
 
         void handleStartGamePressed();
+
+        void handleToggleTeamPressed();
 
         void prepareOpenGameActivity(Intent intent);
 

--- a/app/src/main/java/com/bestCatHustlers/sukodublitz/lobby/LobbyPresenter.java
+++ b/app/src/main/java/com/bestCatHustlers/sukodublitz/lobby/LobbyPresenter.java
@@ -150,7 +150,7 @@ public class LobbyPresenter implements LobbyContract.Presenter {
 
     private void handleBluetoothStateChangeMessage(int state) {
         if (state == BluetoothConstants.STATE_CONNECTED) {
-            view.setStatusText("Connected to" + connectedDeviceName);
+            view.setStatusText("Connected to " + connectedDeviceName);
 
             handleDeviceConnected();
         }

--- a/app/src/main/java/com/bestCatHustlers/sukodublitz/results/ResultsActivity.java
+++ b/app/src/main/java/com/bestCatHustlers/sukodublitz/results/ResultsActivity.java
@@ -75,9 +75,10 @@ public class ResultsActivity extends AppCompatActivity implements ResultsContrac
     }
 
     @Override
-    public void printWinner(String title, String id)
+    public void printWinner(String title, String id, int color)
     {
         winner.setText(String.format("%s %s Wins!", title, id));
+        winner.setTextColor(getResources().getColor(color));
     }
 
     @Override

--- a/app/src/main/java/com/bestCatHustlers/sukodublitz/results/ResultsContract.java
+++ b/app/src/main/java/com/bestCatHustlers/sukodublitz/results/ResultsContract.java
@@ -14,7 +14,7 @@ public class ResultsContract
 
         void printScores(int playerRedScore, int playerBlueScore);
 
-        void printWinner(String title, String id);
+        void printWinner(String title, String id, int color);
 
         void printTie();
 

--- a/app/src/main/java/com/bestCatHustlers/sukodublitz/results/ResultsPresenter.java
+++ b/app/src/main/java/com/bestCatHustlers/sukodublitz/results/ResultsPresenter.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 
 import com.bestCatHustlers.sukodublitz.BoardGame;
 import com.bestCatHustlers.sukodublitz.Player;
+import com.bestCatHustlers.sukodublitz.R;
 import com.bestCatHustlers.sukodublitz.game.GamePresenter;
 
 import java.util.ArrayList;
@@ -41,9 +42,10 @@ public class ResultsPresenter implements ResultsContract.Presenter
         if (winner == null) {
             view.printTie();
         } else {
-            String colour = winner == Player.Team.RED ? "Red" : "Blue";
+            String side = winner == Player.Team.RED ? "Red" : "Blue";
             String title = isMultiplayerMode ? "Team" : "Player";
-            view.printWinner(title, colour);
+            int color = winner == Player.Team.RED ? R.color.secondaryColor : R.color.primaryColor;
+            view.printWinner(title, side, color);
         }
     }
 

--- a/app/src/main/res/layout/activity_lobby.xml
+++ b/app/src/main/res/layout/activity_lobby.xml
@@ -32,13 +32,24 @@
         android:layout_marginTop="120dp" />
 
     <Button
+        android:id="@+id/button_lobby_toggle_team"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:onClick="onToggleTeamPressed"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="120dp"
+        android:backgroundTint="@color/primaryDarkColor"
+        android:textColor="@color/white"
+        android:text="Team Blue" />
+
+    <Button
         android:id="@+id/button_lobby_start_game"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         style="@style/button_long_special"
         android:onClick="onStartGamePressed"
         android:layout_gravity="center"
-        android:layout_marginTop="120dp"
+        android:layout_marginTop="12dp"
         android:text="@string/lobby_start_game" />
 
 </LinearLayout>


### PR DESCRIPTION
The changes made add a button for toggling which team you are on in the lobby. Also some small changes such as changing the AI speed to be more natural, cycling the numbers on the generated puzzle, and showing correct team colours on the number entry pad and results screen.